### PR TITLE
bugfix/accurics_remediation_33102435829060006 - Auto Generated Pull Request From Accurics

### DIFF
--- a/terraform/aws/s3.tf
+++ b/terraform/aws/s3.tf
@@ -112,7 +112,7 @@ resource "aws_s3_bucket" "data_science" {
 
 resource "aws_s3_bucket" "logs" {
   bucket = "${local.resource_prefix.value}-logs"
-  acl    = "log-delivery-write"
+  acl    = "private"
   versioning {
     enabled = true
   }


### PR DESCRIPTION
The Amazon S3 Block Public Access feature provides settings for access points, buckets, and accounts to help manage public access to Amazon S3 resources. By default, new buckets, access points, and objects don't allow public access. However, users can modify bucket policies, access point policies, or object permissions to allow public access. S3 Block Public Access settings override these policies and permissions to limit public access to these resources.